### PR TITLE
Format table using markdown syntax

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,17 +96,17 @@ while True:
     page_num = page_num + 1
         
 with open("progress.md", "w+") as f:
-    f.write("### Issues\n\n| Week | Achievements |")
+    f.write("### Issues\n\n| Week | Achievements |\n| ---- | ------------ |\n")
     for issue in issues:
         f.write(issue + "\n")
     f.write("\n")
 
-    f.write("### Pull Requests\n\n| Week | Achievements |")
+    f.write("### Pull Requests\n\n| Week | Achievements |\n| ---- | ------------ |\n")
     for pr in prs:
         f.write(pr + "\n")
     f.write("\n")
 
-    f.write("### PR Reviews\n\n| Week | Achievements |")
+    f.write("### PR Reviews\n\n| Week | Achievements |\n| ---- | ------------ |\n")
     for review in reviews:
         f.write(review + "\n")
     f.write("\n")


### PR DESCRIPTION
Currently, the table headings and the first line of the body are printed on the same line. 

This PR adds a newline after the table headings as well as hyphens on the second line so that the output is nicely formatted as a table following extended markdown syntax :)

Expected output:
```
| Week | Achievements |
| ---- | ------------ |
| xx Jan 2022 | Submitted Issue: [Issue #1](https://api.github.com/repos/.../issues/1) |
```